### PR TITLE
add more commands

### DIFF
--- a/src/responders/doc.ts
+++ b/src/responders/doc.ts
@@ -51,6 +51,18 @@ const docs: DocResponse[] = [
   {
     match: `.sso`,
     response: `https://eveseat.github.io/docs/configuration/esi_configuration/`
+  },
+  {
+    match: `.install.docker`,
+    response: `https://eveseat.github.io/docs/installation/docker_installation/`
+  },
+  {
+    match: `.install.manual`,
+    response: `https://eveseat.github.io/docs/installation/manual_installation/`
+  },
+  {
+    match: `.logs`,
+    response: `https://eveseat.github.io/docs/troubleshooting/#checking-log-files`
   }
 ]
 


### PR DESCRIPTION
* Adds a command `.docs.logs` that points to the logs section of the troubleshooting page
* `.docs.install.docker` and `.docs.install.manual` for installation instructions. Even tho we don't have `.a.b.c`-style command yet, they seem to work
